### PR TITLE
Preserve non-self closing tags, expose entities, add method Element.setText

### DIFF
--- a/lib/dom-js.js
+++ b/lib/dom-js.js
@@ -213,6 +213,11 @@ Element.prototype.text = function() {
 	}
 	return null;
 };
+Element.prototype.setText = function(data) {
+	this.children = [];
+	this.children.push(new Text(data));
+};
+ 
 
 var Text = function(data){
 	this.text = data;

--- a/lib/dom-js.js
+++ b/lib/dom-js.js
@@ -257,3 +257,4 @@ exports.Comment = Comment;
 exports.CDATASection = CDATASection;
 exports.DomJS = DomJS;
 exports.escape = escape;
+exports.ENTITIES = sax.ENTITIES;

--- a/lib/dom-js.js
+++ b/lib/dom-js.js
@@ -63,7 +63,7 @@ var DomJS = function() {
 
 DomJS.prototype.parse = function(string, cb) {
 	if (typeof string != 'string') {
-		cb(true, 'Data is not a string');
+		cb(new Error('Data is not a string'));
 		return;
 	}
 	var self = this;
@@ -71,7 +71,7 @@ DomJS.prototype.parse = function(string, cb) {
 
 	parser.onerror = function (err) {
 		self.error = true;
-		cb(true, err);
+		cb(err);
 	};
 	
 	parser.ontext = function (text) {
@@ -95,7 +95,7 @@ DomJS.prototype.parse = function(string, cb) {
 	
 	// do nothing on parser.onclosecdata	
 	parser.onopentag = function (node) {
-		var elem = new Element(node.name, node.attributes);
+		var elem = new Element(node.name, node.attributes, null, node.isSelfClosing, parser.line, parser.column);
 		if (self.root == null) {
 			self.root = elem;
 			if ( self.processingInstructions ) {
@@ -135,7 +135,7 @@ DomJS.prototype.parse = function(string, cb) {
 
 	parser.onend = function () {
 		if ( self.error == false) {
-			cb(false, self.root);
+			cb(undefined, self.root);
 		}
 	};
 
@@ -161,10 +161,13 @@ var escape = function(string) {
  * 
  * @constructor Element
  */
-var Element = function(name, attributes, children ) {
+var Element = function(name, attributes, children, isSelfClosing, line, column) {
 	this.name = name;
 	this.attributes = attributes || [];
 	this.children = children || [];
+	this.isSelfClosing = !!isSelfClosing;
+	this.line = line;
+	this.column = column;
 	// undefined by default 
 	// this.processingInstructions = new Array();
 };
@@ -184,7 +187,7 @@ Element.prototype.toXml = function(sb) {
 		
 		sb.buf += ' ' + att + '="' + escape(this.attributes[att]) + '"';
 	}
-	if (this.children.length != 0) {
+	if (!this.isSelfClosing || this.children.length != 0) {
 		sb.buf += '>';
 		for (var i = 0 ; i < this.children.length ; i++) {
 			this.children[i].toXml(sb);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.8",
   "description" : "XML DOM based on sax",
   "dependencies": {
-    "sax": ">=0.1.5"
+    "sax": ">=0.5.0"
   },
   "directories": {
     "lib": "./lib"
@@ -16,5 +16,5 @@
       "type" : "git" , "url" : "https://github.com/teknopaul/dom-js.git" 
   },
   "author": "teknopaul",
-  "contributors": ["Rafal Jonca","Chanwit Kaewkasi"]
+  "contributors": ["Rafal Jonca","Chanwit Kaewkasi","Ian Obermiller"]
 }


### PR DESCRIPTION
Some simple changes to preserve the fidelity of the input xml, especially whether or not a tag was self closing. Also expose ENTITIES so more can be added, and add a setText method to Element.

The isSelfClosing requires sax >= 0.5.0, so I updated the package.json accordingly.
